### PR TITLE
[ADD] <common> modal and ContentHeader

### DIFF
--- a/poodle/src/components/default/common/ContentHeader/ContentHeader.tsx
+++ b/poodle/src/components/default/common/ContentHeader/ContentHeader.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react';
+import * as S from '@/styles/common/ContentHeader';
+
+type ContentHeaderProps = {
+    padding: string,
+    subTitle?: string,
+    title: string,
+    underLineLength: number,
+    border?: string
+    titleFontSize?: number
+}
+
+const ContentHeader: React.FC<ContentHeaderProps> = ({
+    padding, subTitle, title, underLineLength, border, titleFontSize
+}) => {
+    return (
+        <S.ContentHeaderWrapper padding={padding} border={border}>
+            <S.SubTitle>{subTitle}</S.SubTitle>
+            <S.Title fontSize={titleFontSize}>{title}</S.Title>
+            <S.UnderLine length={underLineLength} />
+        </S.ContentHeaderWrapper>
+    );
+};
+
+export default ContentHeader;

--- a/poodle/src/components/default/common/ContentHeader/index.ts
+++ b/poodle/src/components/default/common/ContentHeader/index.ts
@@ -1,0 +1,1 @@
+export { default as default } from './ContentHeader';

--- a/poodle/src/components/default/common/Modal/LoginModal/LoginModal.tsx
+++ b/poodle/src/components/default/common/Modal/LoginModal/LoginModal.tsx
@@ -1,8 +1,13 @@
 import React, { useState, useCallback, FC } from 'react';
 import { useDispatch } from 'react-redux';
+import { useRedirect } from '../../../../../lib/utils/function';
 import * as S from '@/styles/common/Modal';
-import { ModalContent, ModalInput, ModalButtonList, ModalContentProps,
-    openModal
+import { ModalContent,
+    ModalInput,
+    ModalButtonList,
+    ModalContentProps,
+    openModal,
+    clearModal
 } from '..';
 import { RESETMODAL } from '@/core/redux/actions/modal';
 
@@ -12,6 +17,7 @@ type LoginModalProps = ModalContentProps & {
 
 const LoginModal: FC<LoginModalProps> = ({ title, contour, errorSentence, color, onClick }) => {
     const dispatch = useDispatch();
+    const redirectToLink = useRedirect();
     const openResetModal = useCallback(() => {
         openModal(RESETMODAL, dispatch);
     }, [dispatch]);
@@ -25,6 +31,10 @@ const LoginModal: FC<LoginModalProps> = ({ title, contour, errorSentence, color,
             console.log('로그인 !!')
         }
     }, [email, password]);
+    const goToJoin = useCallback(() => {
+        redirectToLink('/join');
+        clearModal(dispatch);
+    }, []);
     return (
         <ModalContent
             title={title}
@@ -58,7 +68,7 @@ const LoginModal: FC<LoginModalProps> = ({ title, contour, errorSentence, color,
                     onClick: onSubmit
                 }]}
             />
-            <S.ETCSentence>
+            <S.ETCSentence onClick={goToJoin}>
                 아직 계정이 없으신가요?
             </S.ETCSentence>
             <S.ETCSentence onClick={openResetModal}>

--- a/poodle/src/components/default/common/Modal/ModalInput.tsx
+++ b/poodle/src/components/default/common/Modal/ModalInput.tsx
@@ -14,7 +14,7 @@ type ModalInputProps = {
 const ModalInput: FC<ModalInputProps> = ({ type, placeholder, value, setValue, textCenter, id, submit }) => {
     const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         setValue(e.target.value);
-    }, [value]);
+    }, [setValue]);
     const onKeyPress = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter' && submit) submit();
     }, [submit]);

--- a/poodle/src/components/default/common/Modal/ResetModal/ResetModal.tsx
+++ b/poodle/src/components/default/common/Modal/ResetModal/ResetModal.tsx
@@ -30,7 +30,7 @@ const RestModal: FC<ResetModalProps> = ({ page, setPage, pageList, buttonList, t
     const [code, setCode] = useState<string>('');
     const [password, setPassword] = useState<string>('');
     const [passwordCheck, setPasswordCheck] = useState<string>('');
-    const getValue = useCallback((id: string): string => {
+    const getResetValue = useCallback((id: string): string => {
         switch (id) {
             case 'email':
                 return email;
@@ -44,7 +44,7 @@ const RestModal: FC<ResetModalProps> = ({ page, setPage, pageList, buttonList, t
                 return '';
         }
     }, [email, code, password, passwordCheck]);
-    const getSetValue = useCallback((id: string): React.Dispatch<React.SetStateAction<string>> => {
+    const getSetResetValue = useCallback((id: string): React.Dispatch<React.SetStateAction<string>> => {
         switch (id) {
             case 'email':
                 return setEmail;
@@ -118,8 +118,8 @@ const RestModal: FC<ResetModalProps> = ({ page, setPage, pageList, buttonList, t
                     pageList[page].inputType === 'password' ||
                     pageList[page].inputType === 'verification'
                 }
-                value={getValue(pageList[page].key)}
-                setValue={getSetValue(pageList[page].key)}
+                value={getResetValue(pageList[page].key)}
+                setValue={getSetResetValue(pageList[page].key)}
                 id={pageList[page].key}
             />}
             <ModalButtonList buttonList={correctedButtonList[page]} color={color} />

--- a/poodle/src/components/default/common/Modal/ResetModal/ResetModal.tsx
+++ b/poodle/src/components/default/common/Modal/ResetModal/ResetModal.tsx
@@ -30,7 +30,7 @@ const RestModal: FC<ResetModalProps> = ({ page, setPage, pageList, buttonList, t
     const [code, setCode] = useState<string>('');
     const [password, setPassword] = useState<string>('');
     const [passwordCheck, setPasswordCheck] = useState<string>('');
-    const getValue = (id: string): string => {
+    const getValue = useCallback((id: string): string => {
         switch (id) {
             case 'email':
                 return email;
@@ -38,11 +38,13 @@ const RestModal: FC<ResetModalProps> = ({ page, setPage, pageList, buttonList, t
                 return password;
             case 'passwordCheck':
                 return passwordCheck;
+            case 'code':
+                return code;
             default:
                 return '';
         }
-    }
-    const getSetValue = (id: string): React.Dispatch<React.SetStateAction<string>> => {
+    }, [email, code, password, passwordCheck]);
+    const getSetValue = useCallback((id: string): React.Dispatch<React.SetStateAction<string>> => {
         switch (id) {
             case 'email':
                 return setEmail;
@@ -50,10 +52,12 @@ const RestModal: FC<ResetModalProps> = ({ page, setPage, pageList, buttonList, t
                 return setPassword;
             case 'passwordCheck':
                 return setPasswordCheck;
+            case 'code':
+                return setCode;
             default:
                 return () => {};
         }
-    }
+    }, [])
     const submit1 = useCallback(() => {
         buttonList[0][0].onClick();
     }, [page]);
@@ -67,7 +71,6 @@ const RestModal: FC<ResetModalProps> = ({ page, setPage, pageList, buttonList, t
         buttonList[1][1].onClick();
     }, [page]);
     const next2 = useCallback(() => {
-        console.log(buttonList);
         buttonList[1][2].onClick();
     }, [page]);
     const prev3 = useCallback(() => {

--- a/poodle/src/styles/common/ContentHeader/index.ts
+++ b/poodle/src/styles/common/ContentHeader/index.ts
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+type ContentHeaderProps = {
+    padding: string,
+    border?: string
+}
+
+export const ContentHeaderWrapper = styled.header<ContentHeaderProps>`
+    padding: ${({ padding }) => padding};
+    ${({ border }) => border};
+`;
+
+export const SubTitle = styled.p`
+    font-family: NanumSquareL;
+    font-size: 20px;
+    font-weight: 300;
+    line-height: 20px;
+    height: 22px;
+    margin-bottom: 8px;
+`;
+
+export const Title = styled.h1<{ fontSize?: number }>`
+    font-family: NanumSquareR;
+    font-size: ${({ fontSize }) => fontSize ? fontSize : 36}px;
+    line-height: ${({ fontSize }) => fontSize ? fontSize : 36}px;
+    font-weight: 400;
+    letter-spacing: -2.3px;
+    margin-bottom: 12px;
+`;
+
+export const UnderLine = styled.hr<{ length: number }>`
+    width: ${({ length }) => length}px;
+    height: 3px;
+    border: none;
+    background-color: #62d3e8;
+`;

--- a/poodle/src/styles/common/Modal/index.ts
+++ b/poodle/src/styles/common/Modal/index.ts
@@ -2,9 +2,12 @@ import styled, { css } from 'styled-components';
 import ClearButton from '@/assets/Modal/Button_clear@3x.png';
 
 export const ModalWrapper = styled.div`
+    z-index: 1;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
-    position: absolute;
+    position: fixed;
     background-color: rgba(0, 0, 0, 0.25);
 `;
 


### PR DESCRIPTION
# 제목을 적어주세요
종종 쓰이는 컴포넌트들을 제작 및 수정
## 목적
여러군데서 사용하므로 편하기 위하여
### 요약
모달은 자잘한 오류 수정을 했고, 종종쓰이는 ContentHeader컴포넌트를 제작했습니다.
### 상세
ContentHeader 컴포넌트는 계정 생성, 메인 페이지, 지원 상황, 마이페이지, 전형 파일 작성, pdf 미리보기 등 에 쓰이는 제목과 부가설명을 하는 컴포넌트로 많은곳에 쓰이므로 독립적인 컴포넌트로 분리했다.
## 영향을 미치는 부분
ContentHeader 컴포넌트의 사용법은
padding: string, // ex) 10px 0
subTitle?: string,
title: string,
underLineLength: number, // 200px을 원하면 200
border?: string // ex) 1px solid black
titleFontSize?: number // 36px을 원하면 36
## 참조(선택)
연관된 이슈 번호들
