### PR TITLE
[CREATE] 미이수 학기를 설정하는 부분의 markup

### DIFF
--- a/poodle/src/components/Grade/NonTransferSemester/column/GradeColumn.tsx
+++ b/poodle/src/components/Grade/NonTransferSemester/column/GradeColumn.tsx
@@ -1,0 +1,18 @@
+import React, { FC } from 'react';
+
+const GradeColumn: FC = ({
+    children
+}) => {
+    return (
+        <td 
+            className="header grade"
+            colSpan={2}
+        >
+            <div>
+                {children}
+            </div>
+        </td>
+    )
+}
+
+export default GradeColumn;

--- a/poodle/src/components/Grade/NonTransferSemester/column/SemesterColumn.tsx
+++ b/poodle/src/components/Grade/NonTransferSemester/column/SemesterColumn.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from 'react';
+import { Checkbox } from '../../../default/ApplicationFormDefault/Checkbox';
+
+interface Props {
+    children: string,
+}
+
+const GradeColumn: FC<Props> = ({
+    children,
+}) => {
+    return (
+        <td 
+            className="semester"
+            colSpan={1}
+        >
+            <div>
+                <Checkbox
+                    onChange={()=>{}}
+                    checked={false}
+                >
+                    {children}
+                </Checkbox>
+            </div>
+        </td>
+    )
+}
+
+export default GradeColumn;

--- a/poodle/src/components/Grade/NonTransferSemester/column/index.ts
+++ b/poodle/src/components/Grade/NonTransferSemester/column/index.ts
@@ -1,0 +1,2 @@
+export { default as GradeColumn } from './GradeColumn';
+export { default as SemesterColumn } from './SemesterColumn';

--- a/poodle/src/components/Grade/NonTransferSemester/index.tsx
+++ b/poodle/src/components/Grade/NonTransferSemester/index.tsx
@@ -1,0 +1,60 @@
+import React, { FC } from 'react';
+import { 
+    GradeTable,
+    GradeSubTitle,
+    SchoolYearRow,
+    SemesterRow,
+} from '../../../styles/Grade';
+import {
+    GradeColumn,
+    SemesterColumn,
+} from './column';
+
+const NonTransferSemester: FC = () => {
+    return (
+        <>
+            <GradeSubTitle>
+                미이수 학기 선택
+            </GradeSubTitle>
+            <GradeTable>
+                <tbody>
+                    <SchoolYearRow>
+                        <GradeColumn>
+                            1학년
+                        </GradeColumn>
+                        <GradeColumn>
+                            2학년
+                        </GradeColumn>
+                        <GradeColumn>
+                            3학년
+                        </GradeColumn>
+                    </SchoolYearRow>
+                    <SemesterRow>
+                        <SemesterColumn>
+                            1학기
+                        </SemesterColumn>
+                        <SemesterColumn>
+                            2학기
+                        </SemesterColumn>
+
+                        <SemesterColumn>
+                            1학기
+                        </SemesterColumn>
+                        <SemesterColumn>
+                            2학기
+                        </SemesterColumn>
+                            
+                        <SemesterColumn>
+                            1학기
+                        </SemesterColumn>
+                        <SemesterColumn>
+                            2학기
+                        </SemesterColumn>
+                    </SemesterRow>
+                </tbody>
+            </GradeTable>
+        </>
+    )
+}
+
+export default NonTransferSemester;


### PR DESCRIPTION
# 학생들 결석과 같은 미이수 입력 페이지 등록
## 목적
학생들이 미이수에 관련된 정보를 입력하는 페이지를 등록하기 위함이다.
### 요약
학생들의 결석, 결과, 지각과 같은 정보를 입력하는 페이지를 마크업하고
redux에 연결했습니다.
### 상세
학생들의 결석, 결과, 지각, 조퇴 같은 정보를 입력하는 페이지를 마크업하고
redux에 연결했습니다.
## 영향을 미치는 부분
## 참조(선택)
