### PR TITLE
[ADD] Github Actions CI/CD Pipelines

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,26 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+      working-directory: ./app
+    - run: npm run build --if-present
+      working-directory: ./app

--- a/.github/workflows/s3_deploy.yml
+++ b/.github/workflows/s3_deploy.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [12.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/s3_deploy.yml
+++ b/.github/workflows/s3_deploy.yml
@@ -1,0 +1,53 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Deploy to S3
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Dependencies
+        run: npm install
+        working-directory: ./app
+
+      - name: Build
+        run: npm run build
+        working-directory: ./app
+
+      - name: Deploy to S3
+        working-directory: ./app
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+        run: |
+          aws s3 cp \
+            --recursive \
+            --region ${{ secrets.S3_REGION }} \
+            dist s3://${{ secrets.S3_BUCKET_NAME }}
+
+      - name: Create invalidation in CloudFront
+        uses: chetan/invalidate-cloudfront-action@master
+        env:
+          DISTRIBUTION: ${{ secrets.CF_DISTRIBUTION_ID }}
+          PATHS: '/*'
+          AWS_REGION: ${{ secrets.S3_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
# Github Actions CI/CD Pipeline 추가
## 목적
### 요약
- Jenkins 파기에 따른 AWS 부분 도입으로 Frontend CI/CD Pipeline 필요성 대두
- Github Actions 이용 ➡️  master에 push시 S3, cloudfront로 자동 배포
### 상세
- master 브랜치에 push하는 경우
  - `Node.js CI` 및 `deploy_s3` action 동작
  - 즉시 production 환경으로 배포되므로 주의 요함. CodeOwners 지정 바람
- master 이외 브랜치에 push하는 경우
  - `Node.js CI`만 동작
  - 커밋 로그 옆 빌드 통과 여부 표시됨
  - PR시 Merge 가능여부 산정 기준에 포함