### PR TITLE
[UPDATE] <createRequestSaga.ts> fix payload

### DIFF
--- a/poodle/src/lib/utils/saga/createRequestSaga.ts
+++ b/poodle/src/lib/utils/saga/createRequestSaga.ts
@@ -13,10 +13,10 @@ export default function createRequestSaga(type: any, request: any) {
         type: SUCCESS,
         payload: response.data,
       });
-    } catch (response) {
+    } catch (e) {
       yield put({
         type: FAILURE,
-        payload: { error: response as ErrorType },
+        payload: e.response.data as ErrorType,
       });
     }
     yield put(finishLoading(type));

--- a/poodle/src/lib/utils/type/index.ts
+++ b/poodle/src/lib/utils/type/index.ts
@@ -1,15 +1,11 @@
 type ErrorType = {
   message: string;
-  response: {
-    status: number;
-  };
+  status: number;
 };
 
 export default ErrorType;
 
 export const errorInitialState = {
   message: '',
-  response: {
-    status: 0,
-  },
+  status: 0,
 };


### PR DESCRIPTION
# createRequsetSaga수정
## 목적
redux payload가 정상 삽입이 안돼서
## 상세
try catch에서 예외를 그대로 payload에 넣는것이 아닌 error.response.data로 변경
## 영향
기존에 reducer에서 action.payload.response.data 로 수정해 사용중이신 분들께선 action.payload로 수정바랍니다.
현재 `yarn start` 시 에러가 나올것입니다. 이는 ErrorType 수정 때문이므로 기존 코드를 수정 바랍니다.
## 관련 pr(선택)
없습니다.