### PR TITLE
Feature/date dropdown menu fix

### DIFF
--- a/poodle/src/components/Info/RowType/UserBirthDayRow.tsx
+++ b/poodle/src/components/Info/RowType/UserBirthDayRow.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState, useEffect, useCallback } from 'react';
 import { DefaultRowWithPicture } from '..';
 import { Dropdown } from '@/components/default/ApplicationFormDefault';
 import { InfoElementContent } from '@/styles/Info';
-import { getDAY, getMONTH, getYEAR } from './constance/UserBirthDayConstance';
+import { getDAY, getMONTH, getYEAR } from '@/lib/utils/function';
 
 interface options {
   VALUE: string;

--- a/poodle/src/lib/utils/function/index.ts
+++ b/poodle/src/lib/utils/function/index.ts
@@ -18,6 +18,12 @@ export const isEmptyCheck = (text: string) => {
   return true;
 };
 
+export const stringedSingleDigitNumberToDoubleDigitNumber = (
+  number: string,
+) => {
+  return `0${number}`;
+};
+
 export const getYEAR = (
   startYear: number,
   lastYear: number,
@@ -40,8 +46,12 @@ export const getMONTH = (
   const buf = [];
   for (let MONTH = startMonth; MONTH <= lastMonth; MONTH++) {
     const stringedMONTH = MONTH.toString();
+    const value =
+      stringedMONTH.length > 1
+        ? stringedMONTH
+        : stringedSingleDigitNumberToDoubleDigitNumber(stringedMONTH);
     buf.push({
-      VALUE: stringedMONTH,
+      VALUE: value,
       LABEL: stringedMONTH,
     });
   }
@@ -55,8 +65,12 @@ export const getDAY = (
   const buf = [];
   for (let DAY = startDay; DAY <= lastDay; DAY++) {
     const stringedDAY = DAY.toString();
+    const value =
+      stringedDAY.length > 1
+        ? stringedDAY
+        : stringedSingleDigitNumberToDoubleDigitNumber(stringedDAY);
     buf.push({
-      VALUE: stringedDAY,
+      VALUE: value,
       LABEL: stringedDAY,
     });
   }


### PR DESCRIPTION
# 날짜 선택 dropdown menu 로직 수정
## 목적
날짜 선택하는 드랍다운 메뉴의 로직 수정
### 요약
원래 한자리수 숫자를 그냥 보냈지만 앞에 0을 붙이게 수정
### 상세
## 영향을 미치는 부분
간단히적어주세요
## 참조(선택)
연관된 이슈 번호들
